### PR TITLE
Extend the pixel format to YCbCr411 which is nothing but YUV_411

### DIFF
--- a/aravis/src/manual/pixel_format.rs
+++ b/aravis/src/manual/pixel_format.rs
@@ -142,4 +142,5 @@ impl PixelFormat {
 	pub const YUV_422_YUYV_PACKED: Self =
 		Self::from_raw(aravis_sys::ARV_PIXEL_FORMAT_YUV_422_YUYV_PACKED);
 	pub const YUV_444_PACKED: Self = Self::from_raw(aravis_sys::ARV_PIXEL_FORMAT_YUV_444_PACKED);
+	pub const YCBCR411_8: Self = Self::from_raw(aravis_sys::ARV_PIXEL_FORMAT_YUV_411_PACKED);
 }


### PR DESCRIPTION
One of the cameras, MatrixVision outputs the color image in YCbCr411_8 PixelFormat. This is basically the same as YUV_411. 